### PR TITLE
Corrige erros tipográficos

### DIFF
--- a/CSharp/Class/GetProperty.cs
+++ b/CSharp/Class/GetProperty.cs
@@ -1,6 +1,6 @@
 using static System.Console;
-using System.Linq
-	;
+using System.Linq;
+
 public class C {
     public static void Main() {
 		var vec1 = new Paragem[3] {

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Códigos soltos usados em respostas minhas no Stack Overflow em português.
 
 Se você achar algum problema, comente lá na pergunta postada no site para que eu possa melhorar. tem link em todos os códigos.
 
-Entenda que muito código aqui está dentro de um contexto. Não é intenção ser o melhor código possível, é dar a melhor resposta possível para quem perguntou, considerando o *background* do autor da pergunta e depende da disponibilidade de tempo que tive para responder. Muitos casos são ajuda para exercícios e adotar a melhor codificação pode não ser a resposta ideal, o autor da pergunta podeestar em outro nível.
+Entenda que muito código aqui está dentro de um contexto. Não é intenção ser o melhor código possível, é dar a melhor resposta possível para quem perguntou, considerando o *background* do autor da pergunta e depende da disponibilidade de tempo que tive para responder. Muitos casos são ajuda para exercícios e adotar a melhor codificação pode não ser a resposta ideal, o autor da pergunta pode estar em outro nível.


### PR DESCRIPTION
Uma minúscula correção de um espaço faltando no `README.md` e, aparentemente (embora não vá quebrar a compilação) um `;` fora do lugar em `CSharp/Class/GetProperty.cs` ao importar o `System.Linq`.